### PR TITLE
feat(TitleTOC): Add styles for the title table of contents 

### DIFF
--- a/docs/0-einfuehrung/innovationsprozess-grundlagen.mdx
+++ b/docs/0-einfuehrung/innovationsprozess-grundlagen.mdx
@@ -3,31 +3,44 @@ sidebar_label: "Grundlagen im Innovationsprozess"
 sidebar_position: 5
 ---
 
-import { TwoColumnGrid } from '@site/src/components/TwoColumnGrid';
-
 # Grundlagen im Innovationsprozess
-
-Reden wir nicht lange drum herum: Die öffentliche Verwaltung tut sich mitunter schwer mit Veränderungen. Dafür gibt es viele, teils gute Gründe: juristische, organisatorische, kulturelle – aber von ihnen handelt dieses Buch nicht. Es ist stattdessen getragen von der Überzeugung, dass Innovation, also die kreative und überraschende Gestaltung von Neuem, auch in der Verwaltung gelingen kann. Und wir möchten Ihnen zeigen, wie.
-
-Veränderung ist in der öffentlichen Verwaltung nicht zuletzt deshalb nötig, weil ja auch die Gesellschaft sich permanent verändert. Während zivilgesellschaftliche Akteure mit Recht mehr Partizipation und Teilhabe an der Gestaltung des öffentlichen Lebens einfordern, entstehen mit der Digitalisierung die Möglichkeiten, das Verwaltungshandeln und damit auch die Beziehung zwischen Staat und Bürger:innen von Grund auf neu zu denken. Das zu tun, erfordert Mut und Offenheit, sich auf Unbekanntes einzulassen.
-
-Mit dem CityLAB Berlin haben wir einen Ort geschaffen, an dem genau das – das gemeinsame Experimentieren mit dem Neuen und Unbekannten – möglich ist. Als öffentliches Innovationslabor, an dem Verwaltung und Stadtgesellschaft kollaborativ an neuen Ideen arbeiten, haben wir täglich damit zu tun, Veränderungsprozesse zu gestalten, und wir lernen dabei ständig dazu. Einiges von dem bisher Gelernten wollen wir mit diesem Buch weitergeben.
-
-Gerade weil Innovationsprozesse jenseits gewohnter Pfade verlaufen, braucht es für sie methodische Grundlagen, die Struktur und Orientierung bieten. Unsere Erfahrung zeigt aber auch, dass dieses Methodenwissen in der öffentlichen Verwaltung noch zu wenig verbreitet ist. Mit diesem Handbuch haben wir deshalb einen praxisnahen Wegbegleiter entwickelt, der darlegt, wie öffentliche Innovationen systematisch entwickelt werden können.
-
-Die in diesem Buch vorgestellten Methoden und Abläufe sind dabei nicht als feststehende Gebrauchsanweisung zu verstehen, sondern als eine Art Baukasten, der frei interpretiert, weiterentwickelt und an eigene Bedürfnisse angepasst werden kann. Wir wissen, dass jeder Innovationsprozess ein Abenteuer ist, das eigene Herausforderungen mit sich bringt. Und gute Abenteuer verlaufen immer überraschend.
-
-Wir freuen uns, dass Sie sich mit uns auf die Reise machen!
-
-<TwoColumnGrid>
-  <p>
-    Dr. Frank Nägele
-    <br />
-    Staatssekretär für Verwaltungs- und Infrastrukturmodernisierung
-  </p>
-  <p>
-    Dr. Benjamin Seibel
-    <br />
-    Leiter CityLAB Berlin
-  </p>
-</TwoColumnGrid>
+# Title 2
+## Title 3
+### Title 4
+### Title 5
+### Title 6
+### Title 7
+## Title 8
+### Title 9
+### Title 10
+## Title 11
+# Title 2
+# Title 2
+# Title 2
+## Title 3
+### Title 4
+### Title 5
+### Title 6
+### Title 7
+## Title 8
+### Title 9
+### Title 10
+## Title 11
+## Title 3
+### Title 4
+### Title 5
+### Title 6
+### Title 7
+## Title 8
+### Title 9
+### Title 10
+## Title 11
+## Title 3
+### Title 4
+### Title 5
+### Title 6
+### Title 7
+## Title 8
+### Title 9
+### Title 10
+## Title 11

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -138,7 +138,7 @@
 
 /* Breadcrumbs (Unsafe, therefore here) */
 .breadcrumbs {
-  @apply flex items-center mt-1.5;
+  @apply flex items-center mt-1.5 flex-wrap;
 }
 
 .breadcrumbs > li {
@@ -207,4 +207,53 @@ html[class*="docs-doc-id-erproben/"] .breadcrumbs > li:nth-of-type(2) > .breadcr
 
 .breadcrumbs__item--active .breadcrumbs__link {
   @apply bg-transparent font-bold text-grey-500;
+}
+
+/* Table of Contents */
+html .theme-doc-toc-desktop {
+  @apply fixed right-0;
+  top: var(--ifm-navbar-height);
+  width: 20vw;
+  max-height: calc(100vh - var(--ifm-navbar-height));
+}
+
+.table-of-contents {
+  @apply p-0 py-[max(2vw,1rem)] lg:opacity-60 transition-opacity hover:opacity-100 !border-t-grey-50;
+}
+
+html[lang="de"] .table-of-contents:before {
+  content: "Auf dieser Seite:";
+  @apply hidden lg:block text-base pb-2 mb-2 border-b border-grey-50 font-bold mt-[1px];
+}
+
+.table-of-contents__left-border {
+  border: none;
+}
+
+.table-of-contents li {
+  @apply m-0 text-base;
+}
+
+.table-of-contents__link {
+  @apply px-1.5 py-0.5 transition-colors text-grey-500 hover:text-blue-500 hover:bg-grey-50 rounded;
+}
+
+div[class*="tocCollapsibleContent_"] ul.table-of-contents > li {
+  @apply mx-0 mb-2 pr-2;
+}
+
+.table-of-contents__link--active {
+  @apply text-grey-500 font-bold;
+}
+
+div[class*="tocCollapsibleContent_"] {
+  @apply lg:p-3 border-b lg:border-b-0 border-grey-50 mb-16 lg:mb-0;
+}
+
+html .theme-doc-toc-mobile {
+  @apply bg-transparent;
+}
+
+html .theme-doc-toc-mobile > button.clean-btn {
+  @apply p-0 pb-2;
 }

--- a/src/theme/Footer/Layout/index.tsx
+++ b/src/theme/Footer/Layout/index.tsx
@@ -16,7 +16,7 @@ export default function FooterLayout({
   copyright,
 }: FooterLayoutProps): JSX.Element {
   return (
-    <footer className={clsx("bg-blue-50", "border-t border-blue-200")}>
+    <footer className={clsx("bg-blue-50", "border-t border-blue-200", "relative z-10")}>
       <div className={clsx("px-6 py-12", "grid gap-y-14 grid-cols-12")}>
         <div className="lg:col-start-2 col-span-12 md:col-span-6 lg:col-span-4">
           <p className="mb-4 text-sm">


### PR DESCRIPTION
This PR styles the table of contents of the page titles on the right side of a page.

See page `einfuehrung/innovationsprozess-grundlagen` for a long example.

![CleanShot 2023-01-26 at 16 56 50](https://user-images.githubusercontent.com/2759340/214884137-cdae034d-fc29-4147-9bd2-e0cab64ffa76.png)
