### PR TITLE
feat: docs base URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,10 +45,6 @@ const config = {
       {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
           routeBasePath: "/buch",
         },
         blog: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ const config = {
 
   presets: [
     [
-      '@docusaurus/preset-classic',
+      "@docusaurus/preset-classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       {
         docs: {
@@ -49,6 +49,7 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+          routeBasePath: "/buch",
         },
         blog: {
           showReadingTime: true,
@@ -70,7 +71,7 @@ const config = {
       docs: {
         sidebar: {
           hideable: true,
-        }
+        },
       },
       navbar: {
         title: "Öffentliches Gestalten",

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -6,4 +6,4 @@ title: Öffentliches Gestalten
 
 Für alle, die sich mutig für eine kreative und gemeinwohlorientierte Transformation der öffentlichen Verwaltung einsetzen.
 
-[Lesen](/docs/einfuehrung/vorwort)
+[Lesen](/buch/einfuehrung/vorwort)


### PR DESCRIPTION
This PR changes the base URL of the book contents from `/docs` to `/buch`. I would say that our main audience will read the German contents, that's why the German route. 