### PR TITLE
fix: dispatch current location to Matomo

### DIFF
--- a/lib/matomoPlugin.js
+++ b/lib/matomoPlugin.js
@@ -17,6 +17,7 @@ export default (function () {
       _paq.push(["enableLinkTracking"]);
       (function () {
         var u = "https://piwik.technologiestiftung-berlin.de/";
+        _paq.push(["setCustomUrl", location.pathname]);
         _paq.push(["setTrackerUrl", u + "matomo.php"]);
         _paq.push(["setSiteId", "31"]);
         var d = document,


### PR DESCRIPTION
This PR attempts to fix Matomo. We are an SPA, so we need to set the URL explicitly.